### PR TITLE
Fix typo in setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -19,7 +19,7 @@ pip install python-dotenv
 pip install gunicorn
 
 pip freeze > requirements.txt
-echo "=== Dependancies installed in virtual environment 'venv' ==="
+echo "=== Dependencies installed in virtual environment 'venv' ==="
 echo "=== To activate it later, run: source venv/bin/activate ==="
 
 # Deactivate the virtual environment


### PR DESCRIPTION
## Summary
- fix spelling typo in `setup.sh`

## Testing
- `bash setup.sh` (fails due to no python environment yet but not needed)


------
https://chatgpt.com/codex/tasks/task_e_68839d726dfc832f83c109fb78f60c06